### PR TITLE
Add public MpdClient#isConnected method

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,8 @@ MpdClient.connect = function(options) {
     client.receive(data);
   });
   client.socket.on('close', function() {
+    // No commands should be execuded on closed connection
+    client.idling = false;
     client.emit('end');
   });
   client.socket.on('error', function(err) {

--- a/index.js
+++ b/index.js
@@ -82,6 +82,10 @@ MpdClient.prototype.setupIdling = function() {
   self.emit('ready');
 };
 
+MpdClient.prototype.isConnected = function() {
+    return this.idling;
+};
+
 MpdClient.prototype.sendCommand = function(command, callback) {
   var self = this;
   callback = callback || noop.bind(this);


### PR DESCRIPTION
In some cases it is useful to know the current state of the client without listening to `end` and `ready` events. So I've created such method with the PR.
