### PR TITLE
Add public API method to disconnect client

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Returns an object.
 
 #### client.sendCommands(commandList, callback)
 
+#### client.disconnect()
+
+Disconnects client from MPD server.
+
 ### Events
 
 #### error(err)

--- a/index.js
+++ b/index.js
@@ -45,6 +45,10 @@ MpdClient.connect = function(options) {
   return client;
 }
 
+MpdClient.disconnect = function() {
+  this.socket.destroy();
+}
+
 MpdClient.prototype.receive = function(data) {
   var m;
   this.buffer += data;


### PR DESCRIPTION
This PR is aimed to create a public API method on `MpdClient` that can close connection.

I know, that I can use just:

``` js
client.socket.destroy()
```

in the app but I believe `socket` property is a implementation detail.
